### PR TITLE
invalid syntax error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="peeter_piper",
-    description="generate piper diagram used in water chemistry analysis; from Peeters 2014"
+    description="generate piper diagram used in water chemistry analysis; from Peeters 2014",
     py_modules=["peeter_piper"],
     version="0.1.1",
     url="https://github.com/inkenbrandt/peeter_piper",


### PR DESCRIPTION
Right now I get "py_modules=["peeter_piper"], SyntaxError: invalid syntax" error, I think one comma should change that